### PR TITLE
Ensured .nojekyll file is copied accross

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,7 +72,10 @@ module.exports = {
       template: `${publicDir}/index.html`
     }),
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
-    new CopyWebpackPlugin([`${publicDir}/**/*`], { context: publicDir }),
+    new CopyWebpackPlugin(
+      [{ from: `${publicDir}/**/*` }, { from: `${publicDir}/.nojekyll` }],
+      { context: publicDir, dot: true }
+    ),
     new CssExtractPlugin({ filename: "[name].[contenthash].css" })
   ],
   stats: ifProd("normal", "minimal")


### PR DESCRIPTION
The .nojekyll file was not being copied by the copy-webpack-plugin, You have to explicitly mention dot files to this plugin.