### PR TITLE
Task/fix setup deploy include dot files

### DIFF
--- a/bin/setup_deploy
+++ b/bin/setup_deploy
@@ -11,3 +11,4 @@ find . -type 'f' -maxdepth 1 | xargs rm -f
 
 # put the contents of build into this directory
 mv build/* .
+mv build/. .

--- a/bin/setup_deploy
+++ b/bin/setup_deploy
@@ -10,5 +10,5 @@ find . -type 'd' -maxdepth 1 | grep -v ".git" | grep -v '^.$' | grep -v 'build' 
 find . -type 'f' -maxdepth 1 | xargs rm -f
 
 # put the contents of build into this directory
+shopt -s dotglob
 mv build/* .
-mv build/. .


### PR DESCRIPTION
Updated setup_deploy script to include dotfiles when moving files from build to parent directory